### PR TITLE
gd: hci: Ignore unexpected status events

### DIFF
--- a/system/gd/hci/hci_layer.cc
+++ b/system/gd/hci/hci_layer.cc
@@ -213,14 +213,13 @@ struct HciLayer::impl {
       command_queue_.front().GetCallback<CommandCompleteView>()->Invoke(
           std::move(command_complete_view));
     } else {
-      ASSERT_LOG(
-          command_queue_.front().waiting_for_status_ == is_status,
-          "0x%02hx (%s) was not expecting %s event",
-          op_code,
-          OpCodeText(op_code).c_str(),
-          logging_id.c_str());
-
-      command_queue_.front().GetCallback<TResponse>()->Invoke(std::move(response_view));
+      if (command_queue_.front().waiting_for_status_ == is_status) {
+        command_queue_.front().GetCallback<TResponse>()->Invoke(std::move(response_view));
+      } else {
+        CommandCompleteView command_complete_view = CommandCompleteView::Create(
+            EventView::Create(PacketView<kLittleEndian>(std::make_shared<std::vector<uint8_t>>(std::vector<uint8_t>()))));
+        command_queue_.front().GetCallback<CommandCompleteView>()->Invoke(std::move(command_complete_view));
+      }
     }
 
     command_queue_.pop_front();


### PR DESCRIPTION
For some reason, on some old devices, the controller will report a remote to support SNIFF_SUBRATING even when it does not. Just ignore the error here (the status event comes from the failure response).

Change-Id: Ifb9a65fd77f21d15a8dc1ced9240194d38218ef6